### PR TITLE
Fixed bash ending to ruby error

### DIFF
--- a/bin/slim_to_erb.rb
+++ b/bin/slim_to_erb.rb
@@ -9,7 +9,7 @@ if !system("command -v html2haml") || !system("command -v haml2slim")
   puts "To fix, please run the following dependency installation command:"
   puts "gem install htmlbeautifier --no-document"
   exit
-fi
+end
 
 puts "Would you like to replace the original files? (Y/n)"
 replace = STDIN.gets.downcase.strip


### PR DESCRIPTION
The method should end with `end` not bash `fi` syntax